### PR TITLE
`$this->authorize` での認可に必要な基底クラスをサンプルコードに明示

### DIFF
--- a/articles/ce7d09eb6d8117.md
+++ b/articles/ce7d09eb6d8117.md
@@ -181,7 +181,9 @@ class PostPolicy
 
 :::details app/Http/Controllers/PostController.php
 ```php:app/Http/Controllers/PostController.php
-class PostContoller
+use App\Http\Controllers\Controller;
+
+class PostContoller extends Controller;
 {
     public function store(Request $request, Community $community): Post
     {


### PR DESCRIPTION
前提クラス（extend）またはトレイト（use）をコードに含めておくと初学者の方が迷わず済むかもしれません！
（PRではlaravel/laravelの標準に倣いextendsにしました）

https://github.com/laravel/laravel/blob/v9.2.0/app/Http/Controllers/Controller.php#L10
https://github.com/laravel/framework/blob/v9.19.0/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php#L19
