### PR TITLE
docs: Publish Go feature flag library article for Advent Calendar Day 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 ## Go
 
+- **[🚩 Feature Flag の量産に耐えられる Go のライブラリを作りました](https://zenn.dev/mpyw/articles/go-context-feature-flags)**
+  &nbsp;[[✍Edit]️](./articles/go-context-feature-flags.md)
 - **[☠️ New Relic Go Agent 完全理解・実践導入ガイド](https://zenn.dev/mpyw/articles/new-relic-go-agent-struggle)**
   &nbsp;[[✍Edit]️](./articles/new-relic-go-agent-struggle.md)
 - **[🥹 なぜ Go ではロガーをコンストラクタ DI してはならないのか](https://zenn.dev/mpyw/articles/go-dont-inject-logger)**

--- a/articles/go-context-feature-flags.md
+++ b/articles/go-context-feature-flags.md
@@ -3,7 +3,7 @@ title: "Feature Flag の量産に耐えられる Go のライブラリを作り�
 emoji: "🚩"
 type: "tech"
 topics: ["go", "context", "featureflags", "oss", "generics"]
-published: false
+published: true
 ---
 
 :::message
@@ -11,12 +11,12 @@ Go ではタブインデントが推奨されていますが，この記事で�
 :::
 
 :::message
-この記事は 7 割ぐらい AI が書いています。
+この記事は 6 割ぐらい AI が書いています。
 :::
 
 # ご挨拶
 
-この記事は [Go - Qiita Advent Calendar 2025](https://qiita.com/advent-calendar/2025/go) (Series 2) の XX 日目の記事です。実は今回 2 回目の参加です。空いてる日があったので，ちょうどいい小ネタで埋めさせてもらいます。
+この記事は [Go - Qiita Advent Calendar 2025](https://qiita.com/advent-calendar/2025/go) (Series 2) の 15 日目の記事です。実は今回 2 回目の参加です。空いてる日があったので，ちょうどいい小ネタで埋めさせてもらいます。
 
 ↓ 前回の記事
 https://zenn.dev/mpyw/articles/new-relic-go-agent-struggle


### PR DESCRIPTION
/schedule 2025-12-15T00:06:45

## Summary
- Go Qiita Advent Calendar 2025 (Series 2) Day 15 の記事を公開設定に変更
- README.md の Go セクションに記事リンクを追加

## Changes
- `articles/go-context-feature-flags.md`: `published: true` に変更，アドベントカレンダー 15 日目に確定
- `README.md`: Go セクションの一番上に記事を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)